### PR TITLE
Out of memory error on recent Eclipse image update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk --no-cache add unzip \
     && mkdir -p /hath/data \
     && mkdir -p /hath/download
 
-FROM eclipse-temurin:8-jre AS release
+FROM eclipse-temurin:8-jre-focal AS release
 
 ENV HatH_ARGS --cache-dir=/hath/data/cache --data-dir=/hath/data/data --download-dir=/hath/download --log-dir=/hath/data/log --temp-dir=/hath/data/temp
 


### PR DESCRIPTION
Based on https://github.com/flyway/flyway/issues/3457, this handles the out of memory error seen in the most recent Eclipse Temurin update by backing off to the last ubuntu image and not using the new one they've migrated to.